### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,21 @@ grape --dp 20002 --aph 40001 --bn '127.0.0.1:20001'
 
 ### Examples
 The following will annonce the `rest:net:util` service on port 31337 and then confirm that the service can be looked up using the `GrenacheClient` object.
+
 ```rust
 extern crate grenache_rust;
 
-use grenache_rust::GrenacheClient;
 use grenache_rust::Grenache;
+use grenache_rust::GrenacheClient;
 use std::{thread, time};
 
-fn main(){
+fn main() {
     let service = "rest:net:util";
     let service_port = 31_337u16;
     let api_url = "http://127.0.0.1:30001";
     let mut client = GrenacheClient::new(api_url);
-    client.start_announcing(service, service_port ).unwrap();
-    thread::sleep(time::Duration::from_secs(1));
-    println!("Service at: {}",client.lookup(service).unwrap());
+    client.start_announcing(service, service_port).unwrap();
+    println!("Service at: {:?}", client.attempt_lookup(service).unwrap());
     client.stop_announcing(service).unwrap();
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@ mod tests {
         let service = "rest:net:util";
         let service_port = 31_337u16;
         let grape_ip = "127.0.0.1";
-        let api_port = "30000";
+        let api_port = "30001";
         let client = GrenacheClient::new(format!("http://{}:{}", grape_ip, api_port));
         let rhs = client.lookup(service).unwrap();
         assert_eq!(Value::Null, rhs[0]);


### PR DESCRIPTION
Since README was previously updated to use port 30001 in [pull request](https://github.com/bitfinexcom/grenache-rust/pull/2), the same port might as well be used in the test. 

Also, instead of sleeping a second to make sure the network has had time to receive the announcement before calling the `lookup` method, the example might as well suggest to use the method `attempt_lookup`.